### PR TITLE
add support for RTEMS builds of pmac

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,8 +1,9 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: 3.2.0b3
+_commit: 3.4.0b2
 _src_path: gh:epics-containers/ioc-template
 description: Generic IOC for the Delta Tau turbo pmac and power pmac motion controllers
 git_platform: github.com
 github_org: epics-containers
 name: ioc-pmac
 repo_uri: git@github.com:epics-containers/ioc-pmac.git
+rtems: true

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: 3.4.0b2
+_commit: 3.4.0
 _src_path: gh:epics-containers/ioc-template
 description: Generic IOC for the Delta Tau turbo pmac and power pmac motion controllers
 git_platform: github.com

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,14 @@
     "name": "epics-containers IOC devcontainer",
     "build": {
         "dockerfile": "../Dockerfile",
-        "target": "developer"
+        "target": "developer",
+        "args": {
+            // Native target development settings ==============================
+            // "EPICS_TARGET_ARCH": "linux-x86_64"
+            // Local cross compilation settings ================================
+            "EPICS_TARGET_ARCH": "RTEMS-beatnik",
+            "IMAGE_EXT": "-rtems-beatnik"
+        }
     },
     "remoteEnv": {
         // allows X11 apps to run inside the container

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,10 +6,10 @@
         "target": "developer",
         "args": {
             // Native target development settings ==============================
-            // "EPICS_TARGET_ARCH": "linux-x86_64"
+            "EPICS_TARGET_ARCH": "linux-x86_64"
             // Local cross compilation settings ================================
-            "EPICS_TARGET_ARCH": "RTEMS-beatnik",
-            "IMAGE_EXT": "-rtems-beatnik"
+            // "EPICS_TARGET_ARCH": "RTEMS-beatnik",
+            // "IMAGE_EXT": "-rtems-beatnik"
         }
     },
     "remoteEnv": {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,30 +15,25 @@ jobs:
       fail-fast: false
       matrix:
         epics-target: [RTEMS-beatnik, linux-x86_64] # , linux-aarch64]
-        target: [developer, runtime]
         include:
+          - os: ubuntu-latest # everyone is on ubuntu-latest
+
           - epics-target: RTEMS-beatnik
-            epics-host: linux-x86_64
             extension: -rtems-beatnik
             platform: linux/amd64
-            os: ubuntu-latest
 
           - epics-target: linux-x86_64
-            epics-host: linux-x86_64
             extension: ""
             platform: linux/amd64
-            os: ubuntu-latest
 
+          # # a temporary name until multi-arch is supported
           # - epics-target: linux-aarch64
-          #   epics-host: linux-aarch64
-          #   # a temporary name until multi-arch is supported
-          #   extension: -native-aarch64
-          #   platform: linux/arm64
-          #   os: ubuntu-latest
+          #     extension: -native-aarch64
+          #     platform: linux/arm64
 
     runs-on: ${{ matrix.os }}
     env:
-      TAG: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}${{ matrix.extension }}-${{ matrix.target }}:${{ github.ref_name }}
+      TAG: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}${{ matrix.extension }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,33 +58,41 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          target: ${{ matrix.target }}
+          target: runtime
           build-args: |
-            TARGET_ARCHITECTURE=${{ matrix.epics-target }}
-            EPICS_HOST_ARCH=${{ matrix.epics-host }}
             IMAGE_EXT=${{ matrix.extension }}
-          tags: ${{ env.TAG }}
           cache-from: type=gha,scope=${{ matrix.epics-target }}
           cache-to: type=gha,mode=max,scope=${{ matrix.epics-target }}
+          tags: ci_test
           load: true
 
       - name: Test image
-        # can't test rtems without some hardware to run on
-        if: contains(${{ matrix.epics-target }}, "RTEMS")
-        run: tests/run-tests.sh
+        # can't test non native without some hardware to run on
+        if: ${{ matrix.epics-target == 'linux-x86_64' }}
+        run: tests/run-tests.sh ci_test
 
-      - name: Push image
+      - name: Push developer image
         if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         uses: docker/build-push-action@v5
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          target: ${{ matrix.target }}
+          target: developer
           build-args: |
-            TARGET_ARCHITECTURE=${{ matrix.epics-target }}
-            EPICS_HOST_ARCH=${{ matrix.epics-host }}
             IMAGE_EXT=${{ matrix.extension }}
-          tags: ${{ env.TAG }}
+          tags: ${{ env.TAG }}-developer:${{ github.ref_name }}
+          push: true
+
+      - name: Push runtime image
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          target: runtime
+          build-args: |
+            IMAGE_EXT=${{ matrix.extension }}
+          tags: ${{ env.TAG }}-runtime:${{ github.ref_name }}
           push: true
 
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        epics-target: [RTEMS-beatnik, linux-x86_64] # , linux-aarch64]
+        epics-target: [RTEMS-beatnik,linux-x86_64] # , linux-aarch64]
         include:
           - os: ubuntu-latest # everyone is on ubuntu-latest
-
           - epics-target: RTEMS-beatnik
             extension: -rtems-beatnik
             platform: linux/amd64
-
           - epics-target: linux-x86_64
             extension: ""
             platform: linux/amd64

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ ioc/config
 
 # podman may leave this around in aborted builds
 .build.swp
+
+# this gets updated during RTEMS builds in devcontainer but we dont want to commit it
+# TODO this entry does not work - why on earth not?
+ioc/configure/CONFIG_SITE.Common.linux-x86_64

--- a/.gitlab/kanikobuild.sh
+++ b/.gitlab/kanikobuild.sh
@@ -19,7 +19,7 @@ else
   DESTINATION=$CI_PROD_REGISTRY/$PROJECT_PATH/$CI_PROJECT_NAME
 fi
 
-CMDROOT="/kaniko/executor --context $CI_PROJECT_DIR --build-arg TARGET_ARCHITECTURE=${ARCH}"
+CMDROOT="/kaniko/executor --context $CI_PROJECT_DIR --build-arg EPICS_TARGET_ARCH=${ARCH}"
 CMD=$CMDROOT"  --target ${TARGET}"
 CMD=$CMD" --destination $DESTINATION-${ARCH}-${TARGET}:$CI_COMMIT_TAG"
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,49 @@
+// Generic IOC debugging launcher
+// To use this l
+// 1. make sure you have gdb installed in your container with
+//    apt update; apt-get install gdb
+// 2. run the IOC once to make sure rutime assets are generated:
+//    cd /epics/ioc; make
+//    ./start.sh
+// 3. stop the IOC with 'exit'
+// 4. In vscode go to the support source in /epics/support/xxx
+// 5. Set any breakpoints in the source code that you require.
+// 6. You may want to set 'HOST_OPT=NO' in CONFIG_SITE and rebuild the support
+// 6. Go to the debug tab and select 'IOC devcontainer debug' from the
+//    RUN AND DEBUG dropdown
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "IOC devcontainer debug",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "/epics/ioc/bin/linux-x86_64/ioc",
+            "args": [
+                "/epics/runtime/st.cmd"
+            ],
+            "stopAtEntry": false,
+            "cwd": "/epics/ioc",
+            "environment": [
+                {
+                    "name": "RUNTIME_DIR",
+                    "value": "/epics/runtime"
+                }
+            ],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_EXT
 
-ARG BASE=7.0.8ec2b7
+ARG BASE=7.0.8ec2
 ARG REGISTRY=ghcr.io/epics-containers
 ARG RUNTIME=${REGISTRY}/epics-base${IMAGE_EXT}-runtime:${BASE}
 ARG DEVELOPER=${REGISTRY}/epics-base${IMAGE_EXT}-developer:${BASE}
@@ -61,8 +61,7 @@ RUN bash ${IOC}/install_proxy.sh
 FROM developer AS runtime_prep
 
 # get the products from the build stage and reduce to runtime assets only
-# TODO ibek will default to copying ibek* and /venv
-RUN ibek ioc extract-runtime-assets /assets ${SOURCE_FOLDER}/ibek* /venv
+RUN ibek ioc extract-runtime-assets /assets
 
 ##### runtime stage ############################################################
 FROM ${RUNTIME} AS runtime
@@ -73,5 +72,5 @@ COPY --from=runtime_prep /assets /
 # install runtime system dependencies, collected from install.sh scripts
 RUN ibek support apt-install-runtime-packages --skip-non-native
 
-ENTRYPOINT ["bash", "-c", "${IOC}/start.sh"]
+CMD "bash -c ${IOC}/start.sh"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-##### build stage ##############################################################
-
-ARG TARGET_ARCHITECTURE=linux-x86_64
-ARG EPICS_HOST_ARCH=linux-x86_64
 ARG IMAGE_EXT
 
-ARG BASE=7.0.8ec2b1
+ARG BASE=7.0.8ec2b7
 ARG REGISTRY=ghcr.io/epics-containers
+ARG RUNTIME=${REGISTRY}/epics-base${IMAGE_EXT}-runtime:${BASE}
+ARG DEVELOPER=${REGISTRY}/epics-base${IMAGE_EXT}-developer:${BASE}
 
-FROM  ${REGISTRY}/epics-base${IMAGE_EXT}-developer:${BASE} AS developer
+##### build stage ##############################################################
+FROM  ${DEVELOPER} AS developer
 
 # The devcontainer mounts the project root to /epics/generic-source
 # Using the same location here makes devcontainer/runtime differences transparent.
@@ -15,7 +14,7 @@ ENV SOURCE_FOLDER=/epics/generic-source
 # connect ioc source folder to its know location
 RUN ln -s ${SOURCE_FOLDER}/ioc ${IOC}
 
-# Get latest ibek while in development. Will come from epics-base when stable
+# Get the current version of ibek
 COPY requirements.txt requirements.txt
 RUN pip install --upgrade -r requirements.txt
 
@@ -55,23 +54,24 @@ RUN pmac/install.sh 2-6-2b1
 COPY ioc ${SOURCE_FOLDER}/ioc
 RUN cd ${IOC} && ./install.sh && make
 
-##### runtime preparation stage ################################################
+# install runtime proxy for non-native builds
+RUN bash ${IOC}/install_proxy.sh
 
+##### runtime preparation stage ################################################
 FROM developer AS runtime_prep
 
 # get the products from the build stage and reduce to runtime assets only
-RUN ibek ioc extract-runtime-assets /assets ${SOURCE_FOLDER}/ibek*
+# TODO ibek will default to copying ibek* and /venv
+RUN ibek ioc extract-runtime-assets /assets ${SOURCE_FOLDER}/ibek* /venv
 
 ##### runtime stage ############################################################
-
-FROM ${REGISTRY}/epics-base${IMAGE_EXT}-runtime:${BASE} AS runtime
+FROM ${RUNTIME} AS runtime
 
 # get runtime assets from the preparation stage
 COPY --from=runtime_prep /assets /
 
 # install runtime system dependencies, collected from install.sh scripts
-RUN ibek support apt-install --runtime
+RUN ibek support apt-install-runtime-packages --skip-non-native
 
-ENV TARGET_ARCHITECTURE ${IMAGE_NAME}
+ENTRYPOINT ["bash", "-c", "${IOC}/start.sh"]
 
-ENTRYPOINT ["/bin/bash", "-c", "${IOC}/start.sh"]

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ To update to the latest version of the template:
 
 pip install copier
 cd ioc-pmac
-copier update -A --trust .
+copier update -a --trust .
 ```

--- a/build
+++ b/build
@@ -25,7 +25,7 @@ if ! docker version &>/dev/null; then docker=podman; else docker=docker; fi
 if $docker buildx version &>/dev/null; then builx=buildx; load=--load; fi
 
 # make sure new repos get their submodule ibek-support
-if [ ! -d ibek-support/_globals ] ; then git submodule update --init ; fi
+if [ ! -d ibek-support/_global ] ; then git submodule update --init ; fi
 
 # build and developer images
 set -x

--- a/build
+++ b/build
@@ -16,9 +16,6 @@ TAG=${TAG:-ec_test}
 if [[ ${T_A} != "linux_x86_64" ]]; then
     # container image extension is the lcase of EPICS_TARGET_ARCH
     IMAGE_EXT=-"${T_A,,}"
-    if [ "$T_A" = "RTEMS-beatnik" ]; then
-        runtime="--build-arg RUNTIME=ghcr.io/epics-containers/rtems-proxy"
-    fi
 fi
 
 cd $(dirname ${0})
@@ -28,11 +25,10 @@ if ! docker version &>/dev/null; then docker=podman; else docker=docker; fi
 if $docker buildx version &>/dev/null; then builx=buildx; load=--load; fi
 
 # make sure new repos get their submodule ibek-support
-if [ ! -d ibek-support ] ; then git submodule update --init ; fi
+if [ ! -d ibek-support/_globals ] ; then git submodule update --init ; fi
 
 # build and developer images
 set -x
 $docker build $buildx -t ${TAG} "${@}" $load \
-    --build-arg EPICS_TARGET_ARCH=$T_A \
     --build-arg IMAGE_EXT=$IMAGE_EXT \
     $runtime --target $TARGET .

--- a/build
+++ b/build
@@ -4,18 +4,21 @@
 # generic local build script for epics-containers repositories                 #
 ################################################################################
 
-# log commands and stop on errors
-set -xe
+set -e
 
-# set TARGET_ARCHITECTURE to rtems for RTEMS based targets
-T_A=${TARGET_ARCHITECTURE:-linux_x86_64}
+# set EPICS_TARGET_ARCH to rtems for RTEMS based targets
+T_A=${EPICS_TARGET_ARCH:-linux_x86_64}
 # set TARGET to runtime for runtime images
 TARGET=${TARGET:-developer}
 # set TAG to override the default tag
 TAG=${TAG:-ec_test}
+
 if [[ ${T_A} != "linux_x86_64" ]]; then
-    # container image extension is the lcase of TARGET_ARCHITECTURE
+    # container image extension is the lcase of EPICS_TARGET_ARCH
     IMAGE_EXT=-"${T_A,,}"
+    if [ "$T_A" = "RTEMS-beatnik" ]; then
+        runtime="--build-arg RUNTIME=ghcr.io/epics-containers/rtems-proxy"
+    fi
 fi
 
 cd $(dirname ${0})
@@ -28,7 +31,8 @@ if $docker buildx version &>/dev/null; then builx=buildx; load=--load; fi
 if [ ! -d ibek-support ] ; then git submodule update --init ; fi
 
 # build and developer images
-$docker build $buildx -t ${TAG} "${@}"  $load \
-    --build-arg TARGET_ARCHITECTURE=$T_A \
+set -x
+$docker build $buildx -t ${TAG} "${@}" $load \
+    --build-arg EPICS_TARGET_ARCH=$T_A \
     --build-arg IMAGE_EXT=$IMAGE_EXT \
-    --target $TARGET .
+    $runtime --target $TARGET .

--- a/ioc/.gitignore
+++ b/ioc/.gitignore
@@ -8,3 +8,4 @@ lib
 .svn*
 iocs/*IOC*
 .idea
+.iocsh_history

--- a/ioc/install.sh
+++ b/ioc/install.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 
-# global install script for support all support modules to reference
+# global install script for all support modules to reference
+# every install.sh script in ibek-support should call this script
+# before it compiles its support module.
 
-x86_cfg='./configure/CONFIG_SITE.Common.linux-x86_64'
+THIS=$(realpath $(dirname $0))
+
+x86_cfg="${THIS}/configure/CONFIG_SITE.Common.linux-x86_64"
 
 # for RTEMS builds don't build for the host architecture, target only
-if [[ $TARGET_ARCHITECTURE == "rtems" ]]; then
+if [[ $EPICS_TARGET_ARCH == "RTEMS"* ]]; then
     touch ${x86_cfg}
     sed -i '/VALID_BUILDS/d' ${x86_cfg}
     echo "VALID_BUILDS=Host" >> ${x86_cfg}
 fi
+
+

--- a/ioc/install_proxy.sh
+++ b/ioc/install_proxy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This script installs a python proxy for the IOC.  The proxy is used to
+# communicate with the IOC from the kubernetes pod where the IOC is non-native
+# and cannot run in the cluster itself.
+
+# Only one proxy will be installed based on the EPICS_TARGET_ARCH
+# the entry point for all proxies will be "epics-proxy start" and will
+# be called by the default IOC start.sh script after it has prepared
+# runtime assets.
+# TODO: at present the rtems-proxy is the only supported proxy and uses
+# rtems-proxy start as its entry point.
+# TODO: consider renaming to ioc-proxy and genericizing. This would
+# negate the need for this script.
+
+# Most IOCs are native linux-x86_64 and will run directly in the cluster
+# so proxy installation is not required.
+
+if [[ $EPICS_TARGET_ARCH == "RTEMS-beatnik" ]] ; then
+    pip install rtems-proxy=="0.3.1"
+fi
+
+# no other proxies supported at present

--- a/ioc/install_proxy.sh
+++ b/ioc/install_proxy.sh
@@ -17,7 +17,7 @@
 # so proxy installation is not required.
 
 if [[ $EPICS_TARGET_ARCH == "RTEMS-beatnik" ]] ; then
-    pip install rtems-proxy=="0.3.1"
+    pip install rtems-proxy=="0.5.0"
 fi
 
 # no other proxies supported at present

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ibek==1.8.2b4
+ibek==2.0.1
 # to install direct from github during development in a branch
 # git+https://github.com/epics-containers/ibek.git@fix-extract-assets

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ibek==1.7.0
+ibek==1.8.1b3
 # to install direct from github during development in a branch
 # git+https://github.com/epics-containers/ibek.git@fix-extract-assets

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ibek==1.8.1b3
+ibek==1.8.2b4
 # to install direct from github during development in a branch
 # git+https://github.com/epics-containers/ibek.git@fix-extract-assets

--- a/services/bl01t-mo-ioc-01/config/ioc.yaml
+++ b/services/bl01t-mo-ioc-01/config/ioc.yaml
@@ -1,0 +1,71 @@
+# yaml-language-server: $schema=https://github.com/epics-containers/ioc-pmac/releases/download/2024.1.2/ibek.ioc.schema.json
+ioc_name: bl01t-mo-ioc-01
+
+description: |
+  Test IOC instance for pmac generic IOC.
+  Connects to the test pmac clipper under giles' desk
+
+entities:
+  - type: epics.EpicsEnvSet
+    name: EPICS_TZ
+    value: "GMT0BST"
+
+  - type: devIocStats.iocAdminSoft
+    IOC: "{{ ioc_name | upper }}"
+
+  - type: pmac.pmacAsynIPPort
+    IP: 172.23.240.97:1025
+    name: BRICK1port
+
+  - type: pmac.GeoBrick
+    IdlePoll: 1000
+    NAXES: 4
+    P: BL47P-MO-BRICK-01
+    name: BRICK1
+    pmacAsynPort: BRICK1port
+
+  - type: pmac.dls_pmac_asyn_motor
+    is_cs: false
+    ACCL: 0.1
+    ADDR: 1
+    Controller: BRICK1
+    DESC: Motor 1
+    DHLM: 25
+    DLLM: -25
+    EGU: mm
+    M: :MOTOR1
+    MRES: -0.01
+    P: BL01T-MO-BRICK-01
+    VELO: 4
+
+  - type: pmac.dls_pmac_asyn_motor
+    is_cs: false
+    ACCL: 0.1
+    ADDR: 2
+    Controller: BRICK1
+    DESC: Motor 1
+    DHLM: 25
+    DLLM: -25
+    EGU: mm
+    M: :MOTOR2
+    MRES: -0.01
+    P: BL01T-MO-BRICK-01
+    VELO: 4
+
+  # test clipper has 3 coordinate systems configured and pmac will segfault at
+  # present if these are not configured.
+  - type: pmac.CS
+    CS: 1
+    IdlePoll: 1000
+    PmacController: BRICK1
+    name: CS2
+  - type: pmac.CS
+    CS: 2
+    IdlePoll: 1000
+    PmacController: BRICK1
+    name: CS1
+  - type: pmac.CS
+    CS: 3
+    IdlePoll: 1000
+    PmacController: BRICK1
+    name: CS3

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -5,6 +5,7 @@
 # all present and correct and that mounting IOC config or ibek config
 # works as expected.
 
+TAG=${1} # pass a tag on the command line to test a prebuilt image
 THIS=$(realpath $(dirname $0))
 ROOT=$(realpath ${THIS}/..)
 CONF=/epics/ioc/config

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -14,7 +14,7 @@ CONF=/epics/ioc/config
 set -ex
 
 # use docker if available else use podman
-if ! docker version &>/dev/null; then alias docker=podman; fi
+if docker version &>/dev/null; then docker=docker; else docker=podman; fi
 
 cd ${ROOT}
 
@@ -23,7 +23,7 @@ export TAG=${TAG:-ec_test}
 if [[ ${TAG} == "ec_test" ]] ; then TARGET=runtime ./build; fi
 
 # try out a test ibek config IOC instance with the generic IOC
-result=$(docker run --rm -v ${THIS}/config:${CONF} ${TAG} /epics/ioc/start.sh 2>&1)
+result=$($docker run --rm -v ${THIS}/config:${CONF} ${TAG} /epics/ioc/start.sh 2>&1)
 
 # check that the IOC output expected results
 if echo "${result}" | grep -i error; then


### PR DESCRIPTION
Adds support for building RTEMS and for making RTEMS builds work inside the developer container.

TODO most of these changes need to be adopted into ioc-template and an additional question asking if RTEMS is to be supported should also be added.