### PR TITLE
bump `stdio-socket` to 1.3.0 (latest)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ibek==3.2.3
 # to install direct from github during development in a branch
 # git+https://github.com/epics-containers/ibek.git@fix-extract-assets
-stdio-socket==1.2.0
+stdio-socket==1.3.0


### PR DESCRIPTION
`stdio-socket 1.3.0` fixes annoying block buffering when deployed on kubernetes