### PR TITLE
Fix Expected Autosave Not Being Used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ WORKDIR ${SOURCE_FOLDER}/ibek-support
 COPY ibek-support/_ansible _ansible
 ENV PATH=$PATH:${SOURCE_FOLDER}/ibek-support/_ansible
 
+COPY ibek-support/autosave/ autosave/
+RUN ansible.sh autosave
+
 COPY ibek-support/motor/ motor/
 RUN ansible.sh motor
 


### PR DESCRIPTION
It was found that the expected autosave was not being used as a fix applied and included in ioc-pmac(7ad71d7) ibek-support(e0f411d) was not applied in the released container image.

The cause was autosave not being included in the ioc-pmac Dockerfile so it was defaulting to the auotsave in ioc-asyn${IMAGE_EXT}-developer:4.45ec2.

This fix of adding autosave to the dockerfile means that the expected ibek-support version is used in the container image.
 
The fix was tested on PPMAC-35 at I15